### PR TITLE
enqueue_at_with_queue内でenqueueでなくenqueue_toでエンキュー

### DIFF
--- a/lib/resque_unit_without_mock/scheduler.rb
+++ b/lib/resque_unit_without_mock/scheduler.rb
@@ -17,7 +17,7 @@ module ResqueUnitWithoutMock::Scheduler
       @@enqueue_ats ||= {}
       @@enqueue_ats[queue] ||= []
       @@enqueue_ats[queue] << { timestamp: timestamp, klass: klass, args: args }
-      Resque.enqueue(klass, *args)
+      Resque.enqueue_to(queue, klass, *args)
     end
 
     def enqueue_ats(queue)

--- a/lib/resque_unit_without_mock/scheduler_assertions.rb
+++ b/lib/resque_unit_without_mock/scheduler_assertions.rb
@@ -1,6 +1,13 @@
 module ResqueUnitWithoutMock::SchedulerAssertions
   def assert_queued_at(expected_timestamp, klass)
-    queue = Resque.queue_for(klass)
+    assert_queued_at_with_queue(Resque.queue_for(klass), expected_timestamp, klass)
+  end
+
+  def assert_not_queued_at(expected_timestamp, klass)
+    assert_not_queued_at_with_queue(Resque.queue_for(klass), expected_timestamp, klass)
+  end
+
+  def assert_queued_at_with_queue(queue, expected_timestamp, klass)
     result = Resque.enqueue_ats(queue).detect { |hash| hash[:timestamp] <= expected_timestamp && hash[:klass] == klass }
     assert(
       result,
@@ -8,8 +15,7 @@ module ResqueUnitWithoutMock::SchedulerAssertions
     )
   end
 
-  def assert_not_queued_at(expected_timestamp, klass)
-    queue = Resque.queue_for(klass)
+  def assert_not_queued_at_with_queue(queue, expected_timestamp, klass)
     result = Resque.enqueue_ats(queue).detect { |hash| hash[:timestamp] <= expected_timestamp && hash[:klass] == klass }
     assert(
       !result,

--- a/test/resque_unit_without_mock/scheduler_assertions_test.rb
+++ b/test/resque_unit_without_mock/scheduler_assertions_test.rb
@@ -30,7 +30,7 @@ class ResqueSchedulersTest < Minitest::TestWithRedis
     assert_queued_at(Time.new(2011,11,11,0,0,3), PrintJob)
   end
 
-  def test_assert_queued_at_with_queue
+  def test_assert_queued_at_with_class_defined_queue
     #      |=> queued!!
     #  |   |\\|\\\\\\\\
     #  1   2  3
@@ -40,5 +40,17 @@ class ResqueSchedulersTest < Minitest::TestWithRedis
     assert_not_queued_at(Time.new(2011,11,11,0,0,1), PrintJob)
     assert_queued_at(Time.new(2011,11,11,0,0,2), PrintJob)
     assert_queued_at(Time.new(2011,11,11,0,0,3), PrintJob)
+  end
+
+  def test_assert_queued_at_with_queue
+    #      |=> queued!!
+    #  |   |\\|\\\\\\\\
+    #  1   2  3
+    assert_not_queued_at_with_queue(:urgent, Time.new(2011,11,11,0,0,2), PrintJob)
+    assert_not_queued_at_with_queue(:urgent, Time.new(2011,11,11,0,0,3), PrintJob)
+    Resque.enqueue_at_with_queue(:urgent, Time.new(2011,11,11,0,0,2), PrintJob)
+    assert_not_queued_at_with_queue(:urgent, Time.new(2011,11,11,0,0,1), PrintJob)
+    assert_queued_at_with_queue(:urgent, Time.new(2011,11,11,0,0,2), PrintJob)
+    assert_queued_at_with_queue(:urgent, Time.new(2011,11,11,0,0,3), PrintJob)
   end
 end


### PR DESCRIPTION
## 課題
enqueue_at_with_queueは引数で渡されたキューでなくクラスで定義さたキューにエンキューしている。
enqueue_toを使って引数で渡されたキューにエンキューする方が元のresque-schedulerの挙動に近く、ユーザーにわかりやすい。

## 対応
- enqueue_at_with_queue内でenqueueでなくenqueue_toでエンキューするよう変更
- ついでにassert_[not_]queued_at_with_queueを追加

## その他
approveいただけたら0.1.2リリースしようと思います。
#6 も合わせて見ていただけるとありがたいです。